### PR TITLE
README - add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-
 mokacoding
 ==========
+
+[www.mokacoding.com](http://www.mokacoding.com/).
 
 `$ ruby new.rb new-post-tile`


### PR DESCRIPTION
I watch the repo for updates but then I don't have a link to the website

You could also put the link in the repo description on github
